### PR TITLE
REFACTOR: vulkansetup.h can now be used as a public interface

### DIFF
--- a/examples/example_vulkan.cpp
+++ b/examples/example_vulkan.cpp
@@ -1,22 +1,52 @@
 #include "direwolf/renderengine.h"
 
-#ifdef DW_VULKAN_ENABLED
+#if defined (DW_VULKAN_ENABLED)
 #include "direwolf/vulkan/vulkansetup.h"
-#endif // DW_VULKAN_ENABLED
+#endif
 
 #include <iostream>
 
 void testNonEngineIntergratedVulkan()
 {
-    std::vector<const char*> desiredVulkanExtensions = { "VK_KHR_surface" };
+#if defined (DW_VULKAN_ENABLED)
+    std::cout << "\n\nTrying to use the non-integrated vulkan stuff\n";
 
-#ifdef DW_VULKAN_ENABLED
-    dw::vulkan::TempVulkanSetupObject vulkanInitObj(&desiredVulkanExtensions);
+    using namespace dw::vulkan;
 
-    if (vulkanInitObj.isValid()) {
-        std::cout << "\nVulkan was successfully initialized\n\n";
+    if (InitializeVulkan()) {
+        std::cout << "\tVulkan was successfully initialized" << std::endl;
     } else {
-        std::cout << "ERROR: Vulkan initialization failed\n";
+        std::cerr << "ERROR: Vulkan initialization failed!" << std::endl;
+        return;
+    }
+
+    // OPTIONAL: We can extract available instance extensions and verify that all extensions we want exist
+    std::vector<VkExtensionProperties> availableExtensions = GetAvailableInstanceExtensions();
+    std::vector<const char*> desiredVulkanExtensions = { "VK_KHR_surface" };
+    bool areExtensionsSupported = true;
+    for (const char* desiredExtension : desiredVulkanExtensions) {
+        areExtensionsSupported &= IsExtensionSupported(desiredExtension, availableExtensions);
+        // NOTE: If the extension isn't supported it'd have to be removed here - if not, the vulkan instance creation will fail!
+    }
+
+    if (!areExtensionsSupported) {
+        std::cerr << "ERROR: Some of the required instance extensions are not supported!" << std::endl;
+        return;
+    }
+
+    // We should create an VulkanInstanceData object.. we don't have to modify any of the default data but names will default to "NullName<*>" if we don't
+    VulkanInstanceInitData vulkanInitData;
+    vulkanInitData.applicationName = "DireWolf Vulkan Application";
+    vulkanInitData.engineName = "DireWolf Engine";
+    vulkanInitData.availableExtensionsHandle = &availableExtensions; // This is optional, it can be left as nullptr. The object will then find this vector by itself
+    vulkanInitData.desiredExtensions = &desiredVulkanExtensions; // This is optional, it can be left as nullptr.
+
+    VkInstance vulkanInstance = CreateVulkanInstance(vulkanInitData);
+
+    std::vector<VkPhysicalDevice> physicalDevices = GetPhysicalDevices(vulkanInstance);
+
+    for (const VkPhysicalDevice& device : physicalDevices) {
+        std::vector<VkExtensionProperties> deviceExtensions = GetPhysicalDeviceExtensions(device);
     }
 #else
     std::cerr << "You're trying to run VULKAN features, but haven't enabled it. Set DW_VULKAN_ENABLED to true in CMAKE to enable it." << std::endl;
@@ -25,9 +55,9 @@ void testNonEngineIntergratedVulkan()
 
 int main() {
     // Setup renderer
-    // dwf::InitData initData { dwf::RendererType::RASTERIZER, dwf::BackendType::VULKAN };
-    // dwf::PlatformData platformData = { nullptr };
-    // auto engine = std::make_unique<dwf::RenderEngine>(platformData, initData);
+    // dw::InitData initData { dw::RendererType::RASTERIZER, dw::BackendType::VULKAN };
+    // dw::PlatformData platformData = { nullptr };
+    // auto engine = std::make_unique<dw::RenderEngine>(platformData, initData);
 
     testNonEngineIntergratedVulkan();
 

--- a/include/direwolf/vulkan/vulkansetup.h
+++ b/include/direwolf/vulkan/vulkansetup.h
@@ -1,41 +1,66 @@
+/* **********************************************************************
+Intended usage:
+
+ 1. Initialize vulkan
+        InitializeVulkan()      [will open runtime libraries and load global level functions]
+
+ 2. Create vulkan instance object with preferences
+    a)  [optional] See which instance extensions that are available by calling
+            GetAvailableInstanceExtensions()
+
+    b)  [optional] Create a vector<const char*> with the names of desired instance extensions
+            Ensure these desired extensions exists in the vector returned by
+            GetAvailableInstanceExtensions by calling IsExtensionSupported()
+
+    c)  Create a VulkanInstanceData object and modify it as you please (Include data from 2a and 2b if you please)
+
+    d)  Create the vulkan instance using the VulkanInstanceData you setup in step 2c) by calling
+        CreateVulkanInstance(VulkanInstanceData)
+
+ 5. Choose which physical device to use
+    a)  Get available physical devices
+            GetPhysicalDevices()
+
+    b)  See what extensions that are available on each devices
+            GetPhysicalDeviceExtensions()
+
+    c)  TODO: Pick the one best suited and do much more stuff afterwards ;)
+
+    ... TODO:
+
+********************************************************************** */
+
 #pragma once
 
-#include "vulkan/vulkanfunctions.h"
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__linux)
+#error "The DireWolf renderer is not yet setup for Vulkan on this platform. Supported operating systems are Linux, Windows and MacOS";
+#endif
 
-#include <stdint.h>
+#include "vulkan/vulkan.h"
+
 #include <vector>
 
 #if defined _WIN32
 #include <windows.h>
 #endif // _WIN32
 
-namespace dw {
-namespace vulkan {
+namespace dw::vulkan {
 
-class TempVulkanSetupObject {
-public:
-    // TODO: add struct to hold initialize data.. e.g. desiredExtensions and names etc. See createVulkanInstance implementation to get an idea of what it should hold
-    TempVulkanSetupObject(std::vector<const char*>* desiredExtensions = nullptr);
-    bool initialize(std::vector<const char*>* desiredExtensions);
-    bool isValid() const { return m_isValid; }
-    static std::vector<const char*> getDefaultInstanceExtensions();
-
-private: // variables
-    bool m_isValid;
-    VkInstance m_instance;
-
-private: // functions
-    bool initLibs();
-    bool initProcAddr();
-    bool isExtensionSupported(const char* extension, std::vector<VkExtensionProperties>* availableExtensions = nullptr) const;
-    bool loadGlobalLevelFunctions();
-    bool loadInstanceLevelFunctions();
-    bool getPhysicalDevices(std::vector<VkPhysicalDevice>& outAvailableDevices);
-    bool getPhysicalDeviceExtensions(const VkPhysicalDevice& device, std::vector<VkExtensionProperties>& outAvailableExtensions);
-    bool loadInstanceLevelFunctionsFromExtensions(const std::vector<const char*>* enabledExtensions = nullptr);
-    bool createVulkanInstance(std::vector<const char*>* desiredExtensions = nullptr);
-    bool getAvailableInstanceExtensions(std::vector<VkExtensionProperties>& outAvailableExtensions) const;
+struct VulkanInstanceInitData {
+    char* applicationName = "NullNameApplication";
+    char* engineName = "NullNameEngine";
+    std::vector<VkExtensionProperties>* availableExtensionsHandle = nullptr;
+    std::vector<const char*>* desiredExtensions = nullptr;
+    // TODO: Extend this with more options?
 };
 
-} // namespace vulkan
-} // namespace dw
+bool InitializeVulkan();
+VkInstance CreateVulkanInstance(const VulkanInstanceInitData& initData);
+std::vector<VkExtensionProperties> GetAvailableInstanceExtensions();
+std::vector<VkPhysicalDevice> GetPhysicalDevices(const VkInstance& instance);
+std::vector<VkExtensionProperties> GetPhysicalDeviceExtensions(const VkPhysicalDevice& device);
+VkPhysicalDeviceFeatures GetPhysicalDeviceFeatures(const VkPhysicalDevice& device);
+VkPhysicalDeviceProperties GetPhysicalDeviceProperties(const VkPhysicalDevice& device);
+bool IsExtensionSupported(const char* extension, const std::vector<VkExtensionProperties>& availableExtensions);
+
+} // namespace dw::vulkan

--- a/src/vulkan/vulkansetup.cpp
+++ b/src/vulkan/vulkansetup.cpp
@@ -2,260 +2,44 @@
 
 #include "vulkanutils.h"
 
-#include <cstring>
 #include <iostream>
 #include <string>
-
-#if defined(__APPLE__) || defined(__linux)
-#include <dlfcn.h>
-#endif
-
-#if defined (_WIN32)
-constexpr char* const VK_LIB_NAME = "vulkan-1.dll";
-#elif defined (__APPLE__)
-constexpr char *const VK_LIB_NAME = "libvulkan.1.dylib";
-#elif defined (__linux)
-constexpr char* const VK_LIB_NAME = "libvulkan.1.so";
-#else
-#error "The DireWolf renderer is not yet setup for Vulkan on this platform. Supported operating systems are Linux and Windows";
-#endif
-
-namespace {
-#if defined(_WIN32)
-HMODULE s_vulkan_library;
-#else
-void *s_vulkan_library;
-#endif
-}
 
 namespace dw::vulkan {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// TODO: should probably take some init-struct
-TempVulkanSetupObject::TempVulkanSetupObject(std::vector<const char*>* desiredExtensions /* = nullptr */)
-: m_isValid(false)
-, m_instance(VK_NULL_HANDLE)
+bool InitializeVulkan()
 {
-#if defined( DW_VERBOSE_LOG_VK )
-    std::cout << "\nTemporaryVulkanSetupObject ctor\n";
-#endif
-    m_isValid = initialize(desiredExtensions);
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::initialize(std::vector<const char*>* desiredExtensions)
-{
-    if (m_isValid) {
-        std::cerr << "Trying to initialize TempVulkanSetupObject after it has already been initialized!" << std::endl;
+    // Get run-time library and initialize global level functions
+    VulkanRTLPtr vulkanRTL = GetRuntimeLibs();
+    if (!vulkanRTL || !InitProcAddress(vulkanRTL) || !InitGlobalLevelFunction()) {
         return false;
     }
 
-    // TODO: this is just temp logic..
-    {
-        std::vector<VkPhysicalDevice> physicalDevices;
-        // Out as soon as something goes wrong
-        if (!initLibs() ||
-            !initProcAddr() ||
-            !loadGlobalLevelFunctions() ||
-            !createVulkanInstance(desiredExtensions) ||
-            !loadInstanceLevelFunctions() ||
-            !loadInstanceLevelFunctionsFromExtensions() ||
-            !getPhysicalDevices(physicalDevices))
-        {
-            return false;
-        }
-
-        for (const VkPhysicalDevice& physicalDevice : physicalDevices) {
-            std::vector<VkExtensionProperties> extensionProperties;
-            getPhysicalDeviceExtensions(physicalDevice, extensionProperties);
-
-            VkPhysicalDeviceFeatures deviceFeatures;
-            VkPhysicalDeviceProperties deviceProperties;
-            vkGetPhysicalDeviceFeatures(physicalDevice, &deviceFeatures);
-            vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
-        }
-    }
-
     return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-bool TempVulkanSetupObject::initLibs()
+VkInstance CreateVulkanInstance(const VulkanInstanceInitData& initData)
 {
-#if defined (_WIN32)
-    s_vulkan_library = LoadLibrary(VK_LIB_NAME);
-#else
-    s_vulkan_library = dlopen(VK_LIB_NAME, RTLD_NOW | RTLD_LOCAL);
-#endif
-    if (!s_vulkan_library) {
-        std::cerr << "Could not connect with a Vulkan Runtime library.\n";
-        return false;
-    }
-
-#if defined ( DW_VERBOSE_LOG_VK )
-    std::cout << "\tSuccessfully connected with a Vulkan Runtime library.\n";
-#endif
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::initProcAddr()
-{
-    // TODO: move this #ifdef part elsewhere?
-#if defined( DW_VERBOSE_LOG_VK )
-#if defined( VK_NO_PROTOTYPES )
-    std::cout << "\tVK_NO_PROTOTYPES is defined\n";
-#else // VK_NO_PROTOTYPES
-    std::cout << "\tWARNING: VK_NO_PROTOTYPES is NOT defined. This may become a potential performance issue.\n";
-#endif // VK_NO_PROTOTYPES
-#endif // DW_VERBOSE_LOG_VK
-
-#if defined (_WIN32)
-#define LoadFunction GetProcAddress
-#elif defined (__linux)
-#define LoadFunction dlsym
-#elif defined (__APPLE__)
-#define LoadFunction dlsym
-#endif
-
-#define EXPORTED_VULKAN_FUNCTION( name )                              \
-    name = (PFN_##name)LoadFunction( s_vulkan_library, #name );         \
-    if ( name == nullptr ) {                                          \
-        std::cerr << "Could not load exported Vulkan function named: "\
-            #name << std::endl;                                       \
-        return false;                                                 \
-    }
-
-#include "listofvulkanfunctions.inl"
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::loadGlobalLevelFunctions()
-{
-#define GLOBAL_LEVEL_VULKAN_FUNCTION( name )                        \
-    name = (PFN_##name)vkGetInstanceProcAddr( nullptr, #name );     \
-    if ( name == nullptr ) {                                        \
-        std::cerr << "Could not load global-level function named: " \
-            #name << std::endl;                                     \
-        return false;                                               \
-    }
-
-#include "listofvulkanfunctions.inl"
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::loadInstanceLevelFunctions()
-{
-#define INSTANCE_LEVEL_VULKAN_FUNCTION( name )                              \
-    name = (PFN_##name)vkGetInstanceProcAddr( m_instance, #name );          \
-    if ( name == nullptr ) {                                                \
-        std::cerr << "Could not load instance-level Vulkan function named: "\
-            #name << std::endl;                                             \
-        return false;                                                       \
-    }                                                                       \
-
-#include "listofvulkanfunctions.inl"
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::loadInstanceLevelFunctionsFromExtensions(const std::vector<const char*>* enabledExtensions /* = nullptr */)
-{
-#define INSTANCE_LEVEL_VULKAN_FUNCTION_FROM_EXTENSION( name, extension )                \
-    if (enabledExtensions) {                                                            \
-        for (const char* const & enabledExtension : *enabledExtensions) {               \
-            if (std::string(enabledExtension) == std::string(extension)) {              \
-                name = (PFN_##name)vkGetInstanceProcAddr(m_instance, #name);            \
-                if( name == nullptr ) {                                                 \
-                    std::cerr << "Could not load instance-level Vulkan function named: "\
-                        #name << std::endl;                                             \
-                    return false;                                                       \
-                }                                                                       \
-            }                                                                           \
-        }                                                                               \
-    }
-
-#include "listofvulkanfunctions.inl"
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// TODO: this needs refactoring
-bool TempVulkanSetupObject::getAvailableInstanceExtensions(std::vector<VkExtensionProperties>& outAvailableExtensions) const
-{
-    if (!s_vulkan_library) {
-        return false;
-    }
-
-    // Input should be an empty vector
-    outAvailableExtensions.clear();
-
-    uint32_t numExtensions = 0;
-
-    // Get number of available extensions
-    if (vkEnumerateInstanceExtensionProperties(nullptr, &numExtensions, nullptr) != VK_SUCCESS || numExtensions == 0) {
-        std::cerr << "Could not get the number of Vulkan Instance extensions." << std::endl;
-        return false;
-    }
-
-    outAvailableExtensions.resize(numExtensions);
-    if (vkEnumerateInstanceExtensionProperties(nullptr, &numExtensions, outAvailableExtensions.data()) != VK_SUCCESS || outAvailableExtensions.size() == 0) {
-        std::cerr << "Could not retrieve Vulkan Instance extensions." << std::endl;
-        return false;
-    }
-
-#if defined( DW_VERBOSE_LOG_VK )
-    std::cout << "\nThe following vulkan instance extensions are available:\n";
-    std::cout << std::left << std::setfill(' ');
-    for (const VkExtensionProperties& extensionProperty : outAvailableExtensions) {
-        prettyPrint(std::cout, extensionProperty, 40, "\t", "\n");
-    }
-    std::cout << std::endl;
-#endif
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::createVulkanInstance(std::vector<const char*>* desiredExtensions)
-{
+    // Get extension vector if user didn't already extract it by himself
+    // TODO: We should look into getting a "scratch pad" arena for temporary variables like these.. what's the benefit?
     std::vector<VkExtensionProperties> availableExtensions;
-    if (!getAvailableInstanceExtensions(availableExtensions)) {
-        std::cerr << "Could not get available instance extensions!" << std::endl;
-        return false;
-    }
-
-    if (desiredExtensions) {
-        for (const char* extension : *desiredExtensions) {
-            if (!isExtensionSupported(extension, &availableExtensions)) {
-                std::cerr << "Extension named '" << extension << "' is not supported." << std::endl;
-                return false;
-            }
-        }
+    std::vector<VkExtensionProperties>* availableExtensionsHandle = initData.availableExtensionsHandle;
+    if (!availableExtensionsHandle) {
+        availableExtensions = GetAvailableInstanceExtensions();
+        availableExtensionsHandle = &availableExtensions;
     }
 
     VkApplicationInfo applicationInfo;
     // The following could be set in an initializer list, but this is clearer for now
     applicationInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     applicationInfo.pNext = nullptr;
-    applicationInfo.pApplicationName = "NullNameApplication";
+    applicationInfo.pApplicationName = initData.applicationName;
     applicationInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
-    applicationInfo.pEngineName = "NullNameEngine";
+    applicationInfo.pEngineName = initData.engineName;
     applicationInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
     applicationInfo.apiVersion = VK_MAKE_VERSION(1, 0, 0);
 
@@ -267,107 +51,136 @@ bool TempVulkanSetupObject::createVulkanInstance(std::vector<const char*>* desir
     instanceCreateInfo.pApplicationInfo = &applicationInfo;
     instanceCreateInfo.enabledLayerCount = 0;
     instanceCreateInfo.ppEnabledLayerNames = nullptr;
+    const std::vector<const char*>* desiredExtensions = initData.desiredExtensions;
     instanceCreateInfo.enabledExtensionCount = desiredExtensions ? desiredExtensions->size() : 0;
     instanceCreateInfo.ppEnabledExtensionNames = desiredExtensions ? desiredExtensions->data() : nullptr;
 
-    if ( (vkCreateInstance( &instanceCreateInfo, nullptr, &m_instance ) != VK_SUCCESS) || (m_instance == VK_NULL_HANDLE) ) {
+    VkInstance instance = VK_NULL_HANDLE;
+
+    if (vkCreateInstance(&instanceCreateInfo, nullptr, &instance) != VK_SUCCESS) {
         std::cerr << "Could not create Vulkan Instance." << std::endl;
-        return false;
+        return VK_NULL_HANDLE;
     }
 
-    return true;
+    if (!LoadInstanceLevelFunctions(instance) || (desiredExtensions && !LoadInstanceLevelFunctionsFromExtensions(instance, *desiredExtensions))) {
+        return VK_NULL_HANDLE;
+    }
+
+    return instance;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-std::vector<const char*> TempVulkanSetupObject::getDefaultInstanceExtensions() {
-    return {
-        "VK_KHR_surface",
-    // "VK_KHR_win32_surface",
-    // "VK_KHR_external_memory_capabilities",
-    // "VK_KHR_external_semaphore_capabilities",
-    // "VK_KHR_external_fence_capabilities",
-    // "VK_KHR_get_physical_device_properties2",
-    // "VK_KHR_get_surface_capabilities2",
-    // "VK_EXT_debug_report",
-    // "VK_EXT_display_surface_counter",
-    // "VK_NV_external_memory_capabilities",
-    // "VK_EXT_debug_utils"
-    };
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::isExtensionSupported(const char* extension, std::vector<VkExtensionProperties>* availableExtensionsPtr /* = nullptr*/) const
+std::vector<VkExtensionProperties> GetAvailableInstanceExtensions()
 {
-    std::vector<VkExtensionProperties> availableExtensions;
-    if (!availableExtensionsPtr) {
-        getAvailableInstanceExtensions(availableExtensions);
-        availableExtensionsPtr = &availableExtensions;
+    // Get number of available extensions
+    uint32_t numExtensions = 0;
+    if (vkEnumerateInstanceExtensionProperties(nullptr, &numExtensions, nullptr) != VK_SUCCESS || numExtensions == 0) {
+        std::cerr << "Could not get the number of Vulkan Instance extensions." << std::endl;
+        return std::vector<VkExtensionProperties>();
     }
 
-    for (VkExtensionProperties availableExtension : *availableExtensionsPtr) {
-        if (strcmp(availableExtension.extensionName, extension) == 0)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool TempVulkanSetupObject::getPhysicalDevices(std::vector<VkPhysicalDevice>& outAvailableDevices)
-{
-    uint32_t numDevices = 0;
-    if (vkEnumeratePhysicalDevices(m_instance, &numDevices, nullptr) != VK_SUCCESS || numDevices == 0) {
-        std::cerr << "Could not get the number of available physical devices." << std::endl;
-        return false;
-    }
-
-    outAvailableDevices.resize(numDevices);
-    if (vkEnumeratePhysicalDevices(m_instance, &numDevices, outAvailableDevices.data()) != VK_SUCCESS) {
-        std::cerr << "Could not enumerate physical devices." << std::endl;
-        return false;
+    std::vector<VkExtensionProperties> returnVec;
+    returnVec.resize(numExtensions);
+    if (vkEnumerateInstanceExtensionProperties(nullptr, &numExtensions, returnVec.data()) != VK_SUCCESS || numExtensions == 0) {
+        std::cerr << "Could not retrieve Vulkan Instance extensions." << std::endl;
+        return std::vector<VkExtensionProperties>();
     }
 
 #if defined( DW_VERBOSE_LOG_VK )
-    std::cout << "\nFound " << numDevices << " physical device(s):\n";
+    std::cout << "\nThe following vulkan instance extensions are available:";
     std::cout << std::left << std::setfill(' ');
-    for (const VkPhysicalDevice& device : outAvailableDevices) {
-        prettyPrint(std::cout, device, 30, "\t", "\n");
+    for (const VkExtensionProperties& extensionProperty : returnVec) {
+        prettyPrint(std::cout, extensionProperty, 40, "\n\t", "");
     }
+    std::cout << std::endl;
 #endif
 
-    return true;
+    return returnVec;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-bool TempVulkanSetupObject::getPhysicalDeviceExtensions(const VkPhysicalDevice& device, std::vector<VkExtensionProperties>& outAvailableExtensions)
+std::vector<VkPhysicalDevice> GetPhysicalDevices(const VkInstance& instance)
 {
+    uint32_t numDevices = 0;
+    if (vkEnumeratePhysicalDevices(instance, &numDevices, nullptr) != VK_SUCCESS || numDevices == 0) {
+        std::cerr << "Could not get the number of available physical devices." << std::endl;
+        return std::vector<VkPhysicalDevice>();
+    }
+
+    std::vector<VkPhysicalDevice> returnVec;
+    returnVec.resize(numDevices);
+    if (vkEnumeratePhysicalDevices(instance, &numDevices, returnVec.data()) != VK_SUCCESS) {
+        std::cerr << "Could not enumerate physical devices." << std::endl;
+        return std::vector<VkPhysicalDevice>();
+    }
+
+#if defined( DW_VERBOSE_LOG_VK )
+    std::cout << "\nFound " << numDevices << " physical device(s):";
+    std::cout << std::left << std::setfill(' ');
+    for (const VkPhysicalDevice& physicalDevice : returnVec) {
+        prettyPrint(std::cout, physicalDevice, 30, "\n\t", "");
+    }
+    std::cout << std::endl;
+#endif
+
+    return returnVec;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::vector<VkExtensionProperties> GetPhysicalDeviceExtensions(const VkPhysicalDevice& device)
+{
+
     uint32_t numExtensions = 0;
     if (vkEnumerateDeviceExtensionProperties(device, nullptr, &numExtensions, nullptr) != VK_SUCCESS || numExtensions == 0) {
         std::cerr << "Could not get the number of physical device extensions." << std::endl;
-        return false;
+        return std::vector<VkExtensionProperties>();
     }
 
-    outAvailableExtensions.resize(numExtensions);
-    if (vkEnumerateDeviceExtensionProperties(device, nullptr, &numExtensions, outAvailableExtensions.data()) != VK_SUCCESS || numExtensions == 0) {
+    std::vector<VkExtensionProperties> returnVec;
+    returnVec.resize(numExtensions);
+    if (vkEnumerateDeviceExtensionProperties(device, nullptr, &numExtensions, returnVec.data()) != VK_SUCCESS || numExtensions == 0) {
         std::cerr << "Could not enumerate physical device extensions." << std::endl;
-        return false;
+        return std::vector<VkExtensionProperties>();
     }
 
 #if defined( DW_VERBOSE_LOG_VK )
     std::cout << std::left << std::setfill(' ');
-    std::cout << "\nThere are " << numExtensions << " extension properties for \"" << device << "\"\n";
-    for (const VkExtensionProperties& extensionProperties : outAvailableExtensions) {
-        prettyPrint(std::cout, extensionProperties, 40, "\t", "\n");
+    std::cout << "\nThere are " << numExtensions << " extension properties for \"" << device << "\"";
+    for (const VkExtensionProperties& extensionProperties : returnVec) {
+        prettyPrint(std::cout, extensionProperties, 40, "\n\t", "");
     }
+    std::cout << std::endl;
 #endif
 
-    return true;
+    return returnVec;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+VkPhysicalDeviceFeatures GetPhysicalDeviceFeatures(const VkPhysicalDevice& device)
+{
+    VkPhysicalDeviceFeatures deviceFeatures;
+    vkGetPhysicalDeviceFeatures(device, &deviceFeatures);
+    return deviceFeatures;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+VkPhysicalDeviceProperties GetPhysicalDeviceProperties(const VkPhysicalDevice& device)
+{
+    VkPhysicalDeviceProperties deviceProperties;
+    vkGetPhysicalDeviceProperties(device, &deviceProperties);
+    return deviceProperties;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool IsExtensionSupported(const char* extension, const std::vector<VkExtensionProperties>& availableExtensions)
+{
+    return IsExtensionSupportedImpl(extension, availableExtensions);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/vulkan/vulkanutils.cpp
+++ b/src/vulkan/vulkanutils.cpp
@@ -3,8 +3,139 @@
 #include <iomanip>
 #include <sstream>
 
-// TODO: fix namespaces
+#if defined(__APPLE__) || defined(__linux)
+#include <dlfcn.h>
+#endif
+
 namespace dw::vulkan {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+VulkanRTLPtr GetRuntimeLibs()
+{
+    VulkanRTLPtr vulkanLibrary;
+
+#if defined (_WIN32)
+    vulkanLibrary = LoadLibrary("vulkan-1.dll");
+#elif defined (__linux )
+    vulkanLibrary = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+#elif defined (__APPLE__ )
+    vulkanLibrary = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+#else
+    std::cerr << "The DireWolf renderer is not yet setup for Vulkan on this platform. Supported operating systems are Linux, Windows and Mac" << std::endl;
+    vulkanLibrary = nullptr;
+#endif
+
+    if (!vulkanLibrary) {
+        std::cerr << "Could not connect with a Vulkan Runtime library.\n";
+    }
+
+#if defined (DW_VERBOSE_LOG_VK)
+    std::cout << "\tSuccessfully connected with a Vulkan Runtime library.\n";
+#endif
+    return vulkanLibrary;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool InitProcAddress(VulkanRTLPtr vulkanRTL)
+{
+// TODO: move this #VK_NO_PROTOTYPES part elsewhere?
+#if defined (DW_VERBOSE_LOG_VK) && defined (VK_NO_PROTOTYPES)
+    std::cout << "\tVK_NO_PROTOTYPES is defined\n";
+#elif defined (DW_VERBOSE_LOG_VK) && !defined (VK_NO_PROTOTYPES)
+    std::cout << "\tWARNING: VK_NO_PROTOTYPES is NOT defined. This may become a potential performance issue.\n";
+#endif
+
+#if defined (_WIN32)
+  #define LoadFunction GetProcAddress
+#elif defined (__linux)
+  #define LoadFunction dlsym
+#elif defined (__APPLE__)
+  #define LoadFunction dlsym
+#endif
+
+#define EXPORTED_VULKAN_FUNCTION( name )                              \
+    name = (PFN_##name)LoadFunction( vulkanRTL, #name );              \
+    if ( name == nullptr ) {                                          \
+        std::cerr << "Could not load exported Vulkan function named: "\
+            #name << std::endl;                                       \
+        return false;                                                 \
+    }
+
+#include "listofvulkanfunctions.inl"
+
+    return true;
+}
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool InitGlobalLevelFunction()
+{
+#define GLOBAL_LEVEL_VULKAN_FUNCTION( name )                        \
+    name = (PFN_##name)vkGetInstanceProcAddr( nullptr, #name );     \
+    if ( name == nullptr ) {                                        \
+        std::cerr << "Could not load global-level function named: " \
+            #name << std::endl;                                     \
+        return false;                                               \
+    }
+
+#include "listofvulkanfunctions.inl"
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool LoadInstanceLevelFunctions(const VkInstance& instance)
+{
+#define INSTANCE_LEVEL_VULKAN_FUNCTION( name )                              \
+    name = (PFN_##name)vkGetInstanceProcAddr( instance, #name );            \
+    if ( name == nullptr ) {                                                \
+        std::cerr << "Could not load instance-level Vulkan function named: "\
+            #name << std::endl;                                             \
+        return false;                                                       \
+    }                                                                       \
+
+#include "listofvulkanfunctions.inl"
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool LoadInstanceLevelFunctionsFromExtensions(const VkInstance& instance, const std::vector<const char*>& enabledExtensions)
+{
+#define INSTANCE_LEVEL_VULKAN_FUNCTION_FROM_EXTENSION( name, extension )            \
+    for (const char* enabledExtension : enabledExtensions) {                        \
+        if (std::string(enabledExtension) == std::string(extension)) {              \
+            name = (PFN_##name)vkGetInstanceProcAddr(instance, #name);              \
+            if( name == nullptr ) {                                                 \
+                std::cerr << "Could not load instance-level Vulkan function named: "\
+                    #name << std::endl;                                             \
+                return false;                                                       \
+            }                                                                       \
+        }                                                                           \
+    }
+
+#include "listofvulkanfunctions.inl"
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool IsExtensionSupportedImpl(const char* extension, const std::vector<VkExtensionProperties>& availableExtensions)
+{
+    for (const VkExtensionProperties& availableExtension : availableExtensions) {
+        if (strcmp(availableExtension.extensionName, extension) == 0) {
+            return true;
+        }
+    }
+
+    std::cerr << "WARNING: \"" << extension << "\" is not a valid extension!" << std::endl;
+
+    return false;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // overloaded operator<<

--- a/src/vulkan/vulkanutils.h
+++ b/src/vulkan/vulkanutils.h
@@ -4,8 +4,30 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
+
+#if defined _WIN32
+#include <windows.h>
+#endif // _WIN32
 
 namespace dw::vulkan {
+
+// Define the VulkanRTLPtr type based on platform
+#if defined (_WIN32)
+typedef HMODULE VulkanRTLPtr;
+#elif defined (__linux) || defined (__APPLE__)
+typedef void* VulkanRTLPtr;
+#else
+typedef void* VulkanRTLPtr;
+#endif
+
+VulkanRTLPtr GetRuntimeLibs();
+bool InitProcAddress(VulkanRTLPtr vulkanRTL);
+bool InitGlobalLevelFunction();
+
+bool LoadInstanceLevelFunctions(const VkInstance& instance);
+bool LoadInstanceLevelFunctionsFromExtensions(const VkInstance& instance, const std::vector<const char*>& enabledExtensions);
+bool IsExtensionSupportedImpl(const char* extension, const std::vector<VkExtensionProperties>& availableExtensions);
 
 // TODO: prettyPrint should be moved to some other util, perhaps logUtils (remember the .inl file)
 


### PR DESCRIPTION
The idea here is to have a pretty self explanatory interface. For all functions that take parameters, there's another function which returns an object of that type. The exception is: `GetAvailableInstanceExtensions()` which only requires that `InitializeVulkan` has been called successfully.

All the previously `private` functions of the `TempVulkanSetupObject` are hidden in the `vulkanutils` files. 