### PR TITLE
Separate Vulkan stuff from main CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9.2)
 project(DireWolf DESCRIPTION "Device Independent Rendering Engine with Other Lively Features")
 
-message("Creating project DireWolf")
+message(STATUS "\nGenerating ${PROJECT_NAME}")
 
 # Compilation flags
 if(MSVC)
@@ -11,27 +11,23 @@ else(MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -std=c++17")
 endif(MSVC)
 
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(DIREWOLF_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(DIREWOLF_BUILD_EXAMPLES "Should the examples folder be added?" OFF) # HACK/TODO: Don't want to add GLFW dep to travis. Do we want to build samples by default?
-option(DIREWOLF_USE_VERBOSE_VULKAN_LOG "Should the Direwolf Vulkan module print verbose info messages?" ON)
 option(DIREWOLF_VULKAN_ENABLED "Should we include vulkan features?" OFF)
 option(DIREWOLF_OPENGL_ENABLED "Should we include OpenGL features?" ON)
 
 set(lib_type STATIC)
-if (BUILD_SHARED_LIBS)
+if (DIREWOLF_BUILD_SHARED_LIBS)
   set(lib_type SHARED)
 endif()
 
-message("Creating DireWolf as a ${lib_type} library")
+message(STATUS "Creating DireWolf as a ${lib_type} library")
 
 # Add library and mandatory sourcefiles
-add_library(direwolf
+add_library(${PROJECT_NAME}
   ${lib_type}
     src/renderengine.cpp
     include/direwolf/renderengine.h
-    # TODO: this shouldn't be here.. remove when vulkan stuff is included in the direwolf wrappers
-    include/direwolf/vulkan/vulkancommons.h
-    include/direwolf/vulkan/vulkansetup.h
 )
 
 if (DIREWOLF_BUILD_EXAMPLES)
@@ -39,68 +35,36 @@ if (DIREWOLF_BUILD_EXAMPLES)
 endif()
 
 if (DIREWOLF_OPENGL_ENABLED)
-  message("Including OpenGL")
+  message(STATUS "\nIncluding OpenGL module to ${PROJECT_NAME}")
 
   add_definitions(-DGLEW_STATIC)
   add_subdirectory(ext/glew-cmake)
 
-  target_include_directories(direwolf
+  target_include_directories(${PROJECT_NAME}
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/ext/glew-cmake/include
-      ${CMAKE_CURRENT_SOURCE_DIR}/ext/glew-cmake/src)
+      ${CMAKE_CURRENT_SOURCE_DIR}/ext/glew-cmake/src
+  )
 
-  target_sources(direwolf
+  target_sources(${PROJECT_NAME}
     PRIVATE
       src/opengl/renderer_ogl.cpp
       src/opengl/irendercontext_ogl.h
       src/opengl/platform/rendercontext_ogl_win.cpp
-      src/opengl/platform/rendercontext_ogl_win.h)
-  target_link_libraries(direwolf libglew_static)
+      src/opengl/platform/rendercontext_ogl_win.h
+  )
+
+  target_link_libraries(${PROJECT_NAME} libglew_static)
 endif (DIREWOLF_OPENGL_ENABLED)
 
 if (DIREWOLF_VULKAN_ENABLED)
-  message("Including Vulkan")
-
-  find_package(Vulkan REQUIRED)
-  if (Vulkan_FOUND)
-    message("Found Vulkan")
-  endif (Vulkan_FOUND)
-
-  target_include_directories(direwolf
-    #TODO this should be PRIVATE.. change when vulkan stuff is included in the direwolf wrappers
-    PUBLIC
-      ${Vulkan_INCLUDE_DIRS})
-
-  target_sources(direwolf
-    PRIVATE
-      # TODO: this should be here src/vulkan/vulkansetup.h.. add when vulkan stuff is included in the direwolf wrappers
-      src/vulkan/listofvulkanfunctions.inl
-      src/vulkan/vulkancommons.cpp
-      src/vulkan/vulkanfunctions.cpp
-      src/vulkan/vulkanfunctions.h
-      src/vulkan/vulkansetup.cpp
-      src/vulkan/vulkanutils.h
-      src/vulkan/vulkanutils.inl
-      src/vulkan/vulkanutils.cpp
-  )
-
-  target_compile_definitions(direwolf
-    PRIVATE
-      # DW_VULKAN_ENABLED=1
-      VK_NO_PROTOTYPES=1
-  )
-
-  if (DIREWOLF_USE_VERBOSE_VULKAN_LOG)
-      target_compile_definitions(direwolf
-        PRIVATE
-          DW_VERBOSE_LOG_VK=1
-      )
-  endif(DIREWOLF_USE_VERBOSE_VULKAN_LOG)
-
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src/vulkan)
 endif (DIREWOLF_VULKAN_ENABLED)
 
-target_include_directories(direwolf
+target_include_directories(${PROJECT_NAME}
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+
+message(STATUS "\nSetup of " ${PROJECT_NAME} " finished!\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if (DIREWOLF_OPENGL_ENABLED)
       src/opengl/platform/rendercontext_ogl_osx.mm
       src/opengl/platform/rendercontext_ogl_osx.h
   )
-  
+
   target_link_libraries(${PROJECT_NAME} libglew_static)
 endif (DIREWOLF_OPENGL_ENABLED)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,12 +1,14 @@
+message(STATUS "\nAdding examples" )
+
 # Always include GLFW for now
 add_subdirectory(ext/glfw)
 
 add_executable(example_vulkan example_vulkan.cpp)
-target_link_libraries(example_vulkan direwolf glfw)
+target_link_libraries(example_vulkan ${PROJECT_NAME} glfw)
 target_include_directories(example_vulkan PUBLIC ../include)
 
 add_executable(example_opengl example_opengl.cpp)
-target_link_libraries(example_opengl direwolf glfw)
+target_link_libraries(example_opengl ${PROJECT_NAME} glfw)
 target_include_directories(example_opengl PUBLIC ../include)
 
 if (DIREWOLF_VULKAN_ENABLED)

--- a/src/vulkan/CMakeLists.txt
+++ b/src/vulkan/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.9.2)
+
+message(STATUS "\nIncluding Vulkan module to ${PROJECT_NAME}")
+
+option(DIREWOLF_VULKAN_USE_VERBOSE_LOG "Should the Direwolf Vulkan module print verbose info messages?" ON)
+
+find_package(Vulkan REQUIRED)
+if (Vulkan_FOUND)
+  message(STATUS "Found Vulkan")
+endif (Vulkan_FOUND)
+
+target_include_directories(${PROJECT_NAME}
+  #TODO this should be PRIVATE.. change when vulkan stuff is included in the direwolf wrappers
+  PUBLIC
+    ${Vulkan_INCLUDE_DIRS}
+)
+
+target_sources(${PROJECT_NAME}
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/include/direwolf/vulkan/vulkancommons.h
+    ${PROJECT_SOURCE_DIR}/include/direwolf/vulkan/vulkansetup.h
+  PRIVATE
+    # TODO: this should be here src/vulkan/vulkansetup.h.. add when vulkan stuff is included in the direwolf wrappers
+    src/vulkan/listofvulkanfunctions.inl
+    src/vulkan/vulkancommons.cpp
+    src/vulkan/vulkanfunctions.cpp
+    src/vulkan/vulkanfunctions.h
+    src/vulkan/vulkansetup.cpp
+    src/vulkan/vulkanutils.h
+    src/vulkan/vulkanutils.inl
+    src/vulkan/vulkanutils.cpp
+)
+
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    VK_NO_PROTOTYPES=1
+)
+
+if (DIREWOLF_VULKAN_USE_VERBOSE_LOG)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+      DW_VERBOSE_LOG_VK=1
+  )
+endif(DIREWOLF_VULKAN_USE_VERBOSE_LOG)


### PR DESCRIPTION
I'm about to add a bunch of stuff that require some CMAKE stuff. Felt like the main `CMakeLists` has become too big, so I decided to first extract the Vulkan stuff and add it to its own `CMakeLists`.

Also did some minor alterations to messages. E.g. added the `STATUS` keyword as otherwise it will print messages in red color. See: https://cmake.org/cmake/help/v3.0/command/message.html